### PR TITLE
Update config.rb to fix spelling errors

### DIFF
--- a/lib/rails_erd/config.rb
+++ b/lib/rails_erd/config.rb
@@ -26,11 +26,11 @@ module RailsERD
       if use_os_x_fonts?
         { normal: "ArialMT",
           bold:   "Arial BoldMT",
-          italic: "Arail ItalicMT" }
+          italic: "Arial ItalicMT" }
       else
         { normal: "Arial",
           bold:   "Arial Bold",
-          italic: "Arail Italic" }
+          italic: "Arial Italic" }
       end
     end
 


### PR DESCRIPTION
Arial misspelled as Arail causes Pango-WARNING message and fallback to Sans font